### PR TITLE
Fix endless methods

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -14,7 +14,7 @@ const TRIGGER_STATEMENTS = [
   /^begin/,
   /.*\sdo/,
 ];
-const SINGLE_LINE_DEFINITION = /;\s*end[\s;]*$/;
+const SINGLE_LINE_DEFINITION = /((;\s*end[\s;]*)|(\s=[\s;]+))/;
 const LINE_PARSE_LIMIT = 1000;
 
 export default class EndsmartOnTypeFormatter

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -32,7 +32,7 @@ suite('formatter tests', () => {
     return edits;
   };
 
-  test('can add end to a block', async () => {
+  test('adds "end" to an if block', async () => {
     const content = 'if foo$';
     const edits = await runFormatter(content);
 
@@ -54,7 +54,7 @@ suite('formatter tests', () => {
     assert.deepEqual(edits![0].range, new vscode.Range(2, 0, 2, 0));
   });
 
-  test('does not add end if it exists already', async () => {
+  test("doesn't add end if it exists already", async () => {
     const content = 'if foo$\nend';
     const edits = await runFormatter(content);
 
@@ -62,20 +62,20 @@ suite('formatter tests', () => {
     assert.strictEqual(edits, undefined);
   });
 
-  test("does not add end when there's already one on the same line", async () => {
-    const contents = ['if foo; end$', 'if foo; end;$', 'if foo; end ; foo()$'];
-    for (const content of contents) {
-      const edits = await runFormatter(content);
-      assert.strictEqual(edits, undefined);
-    }
-  });
+  ['if foo; end$', 'if foo; end;$', 'if foo; end ; foo()$'].forEach(
+    (content) => {
+      test(`doesn't add end when there's already one on the same line - ${content}`, async () => {
+        const edits = await runFormatter(content);
+        assert.strictEqual(edits, undefined);
+      });
+    },
+  );
 
-  test('does not add end for endless methods', async () => {
-    const contents = ['def foo =$', 'def foo = $', 'def foo = bar$'];
-    for (const content of contents) {
+  ['def foo =$', 'def foo = $', 'def foo = bar$'].forEach((content) => {
+    test(`doesn't add end for endless methods — ${content}`, async () => {
       const edits = await runFormatter(content);
-      assert.strictEqual(edits, undefined);
-    }
+      assert.strictEqual(edits, undefined, '');
+    });
   });
 
   test('support nested blocks, add end', async () => {


### PR DESCRIPTION
One of the tests are currently failing:

```
  formatter tests
    ✔ adds "end" to an if block
    ✔ adds an "end" to an assignment method
    ✔ doesn't add end if it exists already
    ✔ doesn't add end when there's already one on the same line - if foo; end$
    ✔ doesn't add end when there's already one on the same line - if foo; end;$
    ✔ doesn't add end when there's already one on the same line - if foo; end ; foo()$
    1) doesn't add end for endless methods — def foo =$
    ✔ doesn't add end for endless methods — def foo = $
    ✔ doesn't add end for endless methods — def foo = bar$
    ✔ support nested blocks, add end
    ✔ support nested blocks, does not add end
    ✔ does not add end with a return if statement
    ✔ does not add end to a random statement even a portion of a trigger keyword is in it
  12 passing (68ms)
  1 failing
  1) formatter tests
       doesn't add end for endless methods — def foo =$:

  AssertionError [ERR_ASSERTION]:
  	at Context.<anonymous> (out/test/extension.test.js:81:20)

1 test failed.
```

I also think the regex doesn’t work well when the cursor is in the middle of the line, and not at EOL.




