### PR TITLE
fix `end` insertion in the middle of an expression when completing a keyword

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -53,6 +53,16 @@ export default class EndsmartOnTypeFormatter
       return;
     }
 
+    // If we have found a beginning keyword, make sure that the cursor is not currently
+    // in the middle of an expression (typical of an if statement e.g. `if ![$]` where
+    // the end insertion would be wrong because it would end up inside `[]`). We do this
+    // by seeing if the line represented by position is an empty line which it should be
+    // if Enter was pressed at the end of the previous line
+    const currentLine = document.lineAt(position.line);
+    if (!currentLine.isEmptyOrWhitespace) {
+      return;
+    }
+
     // Save what the previous line indentation is, if we are using tabs it's directly the value
     // if using spaces we need to calculate an amount
     const indentationLevel = this.indentationFor(lineBeforeNewLine, options);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -14,7 +14,7 @@ suite('formatter tests', () => {
 
   const runFormatter = async (
     content: string,
-  ): Promise<vscode.TextEdit[] | undefined | null> => {
+  ): Promise<[vscode.TextEdit[] | undefined | null, vscode.TextDocument]> => {
     const formatter = new EndsmartOnTypeFormatter();
     // Cursor should be after the newline
     const cursorPosition = content.indexOf('$') + 1;
@@ -28,12 +28,23 @@ suite('formatter tests', () => {
       {insertSpaces: true, tabSize: 2},
       cancellationToken,
     );
-    return edits;
+    return [edits, doc];
+  };
+
+  const applyEdits = async (
+    doc: vscode.TextDocument,
+    edits: vscode.TextEdit[],
+  ): Promise<boolean> => {
+    const workspaceEdit = new vscode.WorkspaceEdit();
+    edits.forEach((edit) =>
+      workspaceEdit.replace(doc.uri, edit.range, edit.newText),
+    );
+    return await vscode.workspace.applyEdit(workspaceEdit);
   };
 
   test('can add end to a block', async () => {
     const content = 'if foo$';
-    const edits = await runFormatter(content);
+    const [edits] = await runFormatter(content);
 
     assert.notStrictEqual(edits, null);
     assert.strictEqual(edits?.length, 1);
@@ -44,7 +55,7 @@ suite('formatter tests', () => {
 
   test('does not add end if it exists already', async () => {
     const content = 'if foo$\nend';
-    const edits = await runFormatter(content);
+    const [edits] = await runFormatter(content);
 
     // No edits should be returned since the doc is balanced
     assert.strictEqual(edits, undefined);
@@ -55,7 +66,7 @@ suite('formatter tests', () => {
 if foo
   begin$
 end`;
-    const edits = await runFormatter(content);
+    const [edits] = await runFormatter(content);
 
     assert.notStrictEqual(edits, null);
     assert.strictEqual(edits?.length, 1);
@@ -70,7 +81,7 @@ if foo
   begin$
   end
 end`;
-    const edits = await runFormatter(content);
+    const [edits] = await runFormatter(content);
 
     // No edits should be returned since the doc is balanced
     assert.strictEqual(edits, undefined);
@@ -79,14 +90,20 @@ end`;
   test('does not add end with a return if statement', async () => {
     const content = `
 return if foo$`;
-    const edits = await runFormatter(content);
+    const [edits] = await runFormatter(content);
     assert.strictEqual(edits, undefined);
   });
 
   test('does not add end to a random statement even a portion of a trigger keyword is in it', async () => {
     const content = `
 Module::Factorify::SbeginClass.method()$`;
-    const edits = await runFormatter(content);
+    const [edits] = await runFormatter(content);
+    assert.strictEqual(edits, undefined);
+  });
+
+  test('does not add end if cursor is inside an if statement expression', async () => {
+    const content = 'if ![$]';
+    const [edits] = await runFormatter(content);
     assert.strictEqual(edits, undefined);
   });
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -31,17 +31,6 @@ suite('formatter tests', () => {
     return [edits, doc];
   };
 
-  const applyEdits = async (
-    doc: vscode.TextDocument,
-    edits: vscode.TextEdit[],
-  ): Promise<boolean> => {
-    const workspaceEdit = new vscode.WorkspaceEdit();
-    edits.forEach((edit) =>
-      workspaceEdit.replace(doc.uri, edit.range, edit.newText),
-    );
-    return await vscode.workspace.applyEdit(workspaceEdit);
-  };
-
   test('can add end to a block', async () => {
     const content = 'if foo$';
     const [edits] = await runFormatter(content);


### PR DESCRIPTION
Related issue: https://github.com/stripe/vscode-endsmart/issues/3

This PR prevent the extension from adding a `end` keyword in the middle of an existing expression. The typical situation this would happen is if you are trying to format something like an `if` expression:

```ruby
if ![$]
```
where `$` is the cursor when Enter is pressed.

You would want this:
```ruby
if ![
$]
end
```
Instead today you get:
```ruby
if ![
$
end]
```

Unfortunately it's rather hard to make our completion work for the ideal case because we would have to be able to understand the code to know what's the appropriate spot for adding the end beyond the line. At the very least this PR will prevent the `end` insertion from happening altogether when we detect a situation where trailing content on the line exist which is an indication that it's probably not a good time/spot to put that `end`